### PR TITLE
Removes clause causing macros with empty parameter list to fail.

### DIFF
--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -937,7 +937,7 @@ int handle_macro(struct assembler_state *state, char **argv, int argc) {
 				end = strchr(location, ')');
 			}
 
-			if (!end || end == location) {
+			if (!end) {
 				ERROR(ERROR_INVALID_DIRECTIVE, state->column, "unterminated parameter list");
 				return 1;
 				// TODO: Free everything


### PR DESCRIPTION
I'm not sure if this was desired behaviour or not, but creating a macro with no parameters, while still having an opening and closing paren (like the one on [line 102 of the kernel](https://github.com/KnightOS/kernel/blob/master/include/platforms.inc#L102)) would cause an "unterminated parameter list" error. This PR removes the part of the if statement that was causing that error.