### PR TITLE
Revert "Removes clause causing macros with empty parameter list to fail."

### DIFF
--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -937,7 +937,7 @@ int handle_macro(struct assembler_state *state, char **argv, int argc) {
 				end = strchr(location, ')');
 			}
 
-			if (!end) {
+			if (!end || end == location) {
 				ERROR(ERROR_INVALID_DIRECTIVE, state->column, "unterminated parameter list");
 				return 1;
 				// TODO: Free everything


### PR DESCRIPTION
Reverts KnightOS/scas#51

Seems to have introduced a bug where the assembler could end up in an infinite loop.