### PR TITLE
Fix for #376

### DIFF
--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -360,7 +360,7 @@ int try_match_instruction(struct assembler_state *state, char **_line) {
 				scas_log(L_DEBUG, "Postponing evaluation of '%s' to linker", ref->value_provided);
 				late_immediate_t *late_imm = malloc(sizeof(late_immediate_t));
 				late_imm->instruction_address = state->current_area->data_length;
-				late_imm->base_address = state->current_area->data_length + (match->instruction->width / 8);
+				late_imm->base_address = state->PC + (match->instruction->width / 8);
 				late_imm->address = state->current_area->data_length + (imm->shift / 8);
 				late_imm->width = imm->width;
 				late_imm->type = imm->type;


### PR DESCRIPTION
Looks good.

```
noam@development:~/Documents/Development/knightos$ cat a.asm
a:
	jr a

.org 0x200

b:
	jr b
	jr a
noam@development:~/Documents/Development/knightos$ scas -vvvvv a.asm -o a
Loaded instruction set: z80
Assembling input file: 'a.asm'
  Matched string 'jr a' to instruction 'JR_^A<8>'
    Postponing evaluation of 'a' to linker
    Added 2 bytes to area '_CODE' (now 2 bytes total)
Assembler handling line '.org 0x200'
  Matched directive 'org' at a.asm:4
    Set origin to 0x00000200 from org directive
  Assembler handling line 'jr b'
  Matched string 'jr b' to instruction 'JR_^A<8>'
    Postponing evaluation of 'b' to linker
    Added 2 bytes to area '_CODE' (now 4 bytes total)
  Assembler handling line 'jr a'
  Matched string 'jr a' to instruction 'JR_^A<8>'
    Postponing evaluation of 'a' to linker
    Added 2 bytes to area '_CODE' (now 6 bytes total)
  Assembler handling line ''
Linking area _CODE
Resolving immediate values for area '_CODE' at 00000000
  Immediate value result: 0xFFFFFFFE (width 8, base address 0x00000002)
  Immediate value result: 0xFFFFFFFE (width 8, base address 0x00000202)
  Immediate value result: 0xFFFFFDFC (width 8, base address 0x00000204)
Added error 'Value truncated' at a.asm:8:0
Linker returned 1 errors, 0 warnings
a.asm:8:0: error #2: Value truncated
	jr a

Exiting with status code 1, cleaning up
``` 
(cut out unrelated debug messages)