### PR TITLE
Handle \\, \", and \' in unescape_string()

### DIFF
--- a/common/stringop.c
+++ b/common/stringop.c
@@ -172,6 +172,11 @@ int unescape_string(char *string) {
 				string[i - 1] = '\r';
 				memmove(string + i, string + i + 1, len - i);
 				break;
+			case '\\':
+			case '"':
+			case '\'':
+				memmove(string + i - 1, string + i, len - i + 1);
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
For some reason, before or after this change, having two instances of `\"` in a string literal errors, while one works. (for example, `.db "\""` vs `.db "\"\""`).

But this change should be correct, whatever the issue is elsewhere causing that bug.

(`unescape_string()` should probably also produce an error on unknown escapes; since it otherwise silently results in unexpected and undesired results.)