### PR TITLE
Fix building kernel

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -23,6 +23,4 @@ tasks:
       # Temporary: use scas PR
       git checkout scas
       mkdir bin/TI84pSE -p
-      valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/00/" --symbols bin/TI84pSE/00.sym --listing bin/TI84pSE/00.list src/00/base.asm -o bin/TI84pSE/00.bin -vv
-      valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/01/" --symbols bin/TI84pSE/01.sym --listing bin/TI84pSE/01.list src/01/base.asm -o bin/TI84pSE/01.bin -vv
-      valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/02/" --symbols bin/TI84pSE/02.sym --listing bin/TI84pSE/02.list src/02/base.asm -o bin/TI84pSE/02.bin -vv
+      make AS="valgrind --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas"

--- a/.build.yml
+++ b/.build.yml
@@ -2,8 +2,14 @@ image: archlinux
 packages:
   - make
   - cmake
+  - mkrom
+  - patchrom
+  - genkfs
+  - mktiupgrade
+  - valgrind
 sources:
   - https://github.com/knightos/scas
+  - https://github.com/knightos/kernel
 environment:
   project: scas
 tasks:
@@ -13,3 +19,7 @@ tasks:
       cd build
       cmake -DCMAKE_BUILD_TYPE=Release ..
       make
+      cd ../../kernel
+      mkdir bin/TI84pSE -p
+      valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/00/" --symbols bin/TI84pSE/00.sym --listing bin/TI84pSE/00.list src/00/base.asm -o bin/TI84pSE/00.bin -vv
+      if [[ "$(grep ERROR\ SUMMARY log | cut -d\  -f4)" != "0" ]] ; then echo Memory error ; exit 1 ; fi

--- a/.build.yml
+++ b/.build.yml
@@ -21,7 +21,7 @@ tasks:
       make
       cd ../../kernel
       # Temporary: use scas PR
-      gco scas
+      git checkout scas
       mkdir bin/TI84pSE -p
       valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/00/" --symbols bin/TI84pSE/00.sym --listing bin/TI84pSE/00.list src/00/base.asm -o bin/TI84pSE/00.bin -vv
       if [[ "$(grep ERROR\ SUMMARY log | cut -d\  -f4)" != "0" ]] ; then echo Memory error ; exit 1 ; fi

--- a/.build.yml
+++ b/.build.yml
@@ -24,3 +24,5 @@ tasks:
       git checkout scas
       mkdir bin/TI84pSE -p
       valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/00/" --symbols bin/TI84pSE/00.sym --listing bin/TI84pSE/00.list src/00/base.asm -o bin/TI84pSE/00.bin -vv
+      valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/01/" --symbols bin/TI84pSE/01.sym --listing bin/TI84pSE/01.list src/01/base.asm -o bin/TI84pSE/01.bin -vv
+      valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/02/" --symbols bin/TI84pSE/02.sym --listing bin/TI84pSE/02.list src/02/base.asm -o bin/TI84pSE/02.bin -vv

--- a/.build.yml
+++ b/.build.yml
@@ -20,6 +20,8 @@ tasks:
       cmake -DCMAKE_BUILD_TYPE=Release ..
       make
       cd ../../kernel
+      # Temporary: use scas PR
+      gco scas
       mkdir bin/TI84pSE -p
       valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/00/" --symbols bin/TI84pSE/00.sym --listing bin/TI84pSE/00.list src/00/base.asm -o bin/TI84pSE/00.bin -vv
       if [[ "$(grep ERROR\ SUMMARY log | cut -d\  -f4)" != "0" ]] ; then echo Memory error ; exit 1 ; fi

--- a/.build.yml
+++ b/.build.yml
@@ -24,4 +24,3 @@ tasks:
       git checkout scas
       mkdir bin/TI84pSE -p
       valgrind -s --track-origins=yes --leak-check=full --error-exitcode=1 ../scas/build/scas  --define TI84pSE --include "include/;bin/TI84pSE/;src/00/" --symbols bin/TI84pSE/00.sym --listing bin/TI84pSE/00.list src/00/base.asm -o bin/TI84pSE/00.bin -vv
-      if [[ "$(grep ERROR\ SUMMARY log | cut -d\  -f4)" != "0" ]] ; then echo Memory error ; exit 1 ; fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test/
 build/
 .lvimrc
 tables/z80.c
+.ccls
+.ccls-cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.5)
 
 project(scas C)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -std=c99 -D_XOPEN_SOURCE=700")
-set(CMAKE_C_FLAGS_DEVEL "-Werror -g -Og")
 
 if(WIN32)
     set(CMAKE_C_FLAGS "-Wl,--allow-multiple-definition")

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -442,7 +442,14 @@ int try_match_instruction(struct assembler_state *state, char **_line) {
 				transform_local_labels(expression, state->last_global_label);
 				const char *file_name = stack_peek(state->file_name_stack);
 				transform_relative_labels(expression, state->last_relative_label, file_name);
+				symbol_t sym_pc = {
+					.type = SYMBOL_LABEL,
+					.value = state->PC,
+					.name = "$"
+				};
+				list_add(state->equates, &sym_pc);
 				result = evaluate_expression(expression, state->equates, &error, &symbol);
+				state->equates->length -= 1;
 				if (error == EXPRESSION_BAD_SYMBOL) {
 					if (scas_runtime.options.explicit_import && strcmp(symbol, "$") != 0) {
 						unresolved_symbol_t *unresolved_sym = malloc(sizeof(unresolved_symbol_t));

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -329,7 +329,7 @@ int try_add_label(struct assembler_state *state, char **line) {
 
 	/* Add label */
 	symbol_t *sym = malloc(sizeof(symbol_t));
-	sym->exported = 1; /* TODO: Support explicit export */
+	sym->exported = !scas_runtime.options.explicit_export;
 	sym->type = SYMBOL_LABEL;
 	sym->value = state->PC + scas_runtime.options.origin;
 	sym->defined_address = state->current_area->data_length;

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -172,6 +172,9 @@ int try_expand_macro(struct assembler_state *state, char **line) {
 	if (strstr(*line, "macro") == *line + 1) { // Cannot expand macros while defining them
 		return 0;
 	}
+	if (strstr(*line, "undefine") == *line + 1) { // Should not expand while removing
+		return 0;
+	}
 	if (strstr(*line, "ifdef") == *line + 1) { // Should not expand when testing for existence
 		return 0;
 	}

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -710,11 +710,7 @@ object_t *assemble(FILE *file, const char *file_name, assembler_settings_t *sett
 		macro_free(macro);
 	}
 	list_free(state.macros);
-	for (int i = 0; i < state.equates->length; i += 1) {
-		symbol_t *sym = (symbol_t*)state.equates->items[i];
-		free(sym->name);
-		free(sym);
-	}
+	// Equates are also added to an area's symbols list, so they're cleaned up there
 	list_free(state.equates);
 	stack_free(state.source_map_stack);
 	free(state.instruction_buffer);

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -178,6 +178,12 @@ int try_expand_macro(struct assembler_state *state, char **line) {
 	if (strstr(*line, "ifdef") == *line + 1) { // Should not expand when testing for existence
 		return 0;
 	}
+	// Shouldn't expand macros in equates
+	if ((**line == '.' || **line == '#')) {
+		if (code_strstr(*line, ".equ") || code_strchr(*line, '=')) {
+			return 0;
+		}
+	}
 	int i;
 	for (i = 0; i < state->macros->length; i++) {
 		macro_t *macro = state->macros->items[i];
@@ -608,8 +614,8 @@ object_t *assemble(FILE *file, const char *file_name, assembler_settings_t *sett
 		try_empty_line,
 		try_parse_inside_macro,
 		try_split_line,
-		try_expand_macro,
 		try_add_label,
+		try_expand_macro,
 		try_handle_directive,
 		try_match_instruction,
 	};

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -433,6 +433,8 @@ int handle_undef(struct assembler_state *state, char **argv, int argc) {
 		return 1;
 	}
 
+	scas_log(L_DEBUG, "Looking for %s", argv[0]);
+
 	int i;
 	for (i = 0; i < state->macros->length; i++) {
 		macro_t *m = state->macros->items[i];

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -152,6 +152,7 @@ int handle_block(struct assembler_state *state, char **argv, int argc) {
 
 	if (error == EXPRESSION_BAD_SYMBOL) {
 		ERROR(ERROR_UNKNOWN_SYMBOL, state->column, symbol);
+		free_expression(expression);
 		return 1;
 	} 
 
@@ -167,6 +168,8 @@ int handle_block(struct assembler_state *state, char **argv, int argc) {
 			result = 0;
 		}
 	}
+	free(buffer);
+	free_expression(expression);
 	return 1;
 }
 

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -763,6 +763,7 @@ int handle_equ(struct assembler_state *state, char **argv, int argc) {
 		sym->value = result;
 		sym->exported = 0;
 		list_add(state->equates, sym);
+		list_add(state->current_area->symbols, sym);
 		scas_log(L_DEBUG, "Added equate '%s' with value 0x%08X", sym->name, sym->value);
 	}
 	return 1;

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -612,9 +612,18 @@ static void printf_putc(char c) {
 	putchar(c);
 }
 
-int handle_printf(struct assembler_state *state, char **argv, int argc) {
+int handle_echo(struct assembler_state *state, char **argv, int argc) {
 	if (argc == 0) {
 		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "echo expects 1+ arguments");
+		return 1;
+	}
+	(void)argv;
+	return 1;
+}
+
+int handle_printf(struct assembler_state *state, char **argv, int argc) {
+	if (argc == 0) {
+		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "printf expects 1+ arguments");
 		return 1;
 	}
 	int len = strlen(argv[0]);
@@ -1279,7 +1288,7 @@ struct directive directives[] = {
 	{ "dl", handle_dl, DELIM_COMMAS },
 	{ "ds", handle_block, DELIM_COMMAS },
 	{ "dw", handle_dw, DELIM_COMMAS },
-	//{ "echo", handle_echo, DELIM_COMMAS | DELIM_WHITESPACE },
+	{ "echo", handle_echo, DELIM_COMMAS | DELIM_WHITESPACE },
 	{ "elif", handle_elseif, 0 },
 	{ "else", handle_else, 0 },
 	{ "elseif", handle_elseif, 0 },

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -748,8 +748,20 @@ int handle_equ(struct assembler_state *state, char **argv, int argc) {
 		ERROR_NO_ARG(ERROR_INVALID_SYNTAX, state->column);
 		return 1;
 	} else {
+		transform_local_labels(expression, state->last_global_label);
+		int len = state->equates->length;
+		for (int i = 0; i < state->current_area->symbols->length; i += 1) {
+			list_add(state->equates, state->current_area->symbols->items[i]);
+		}
+		symbol_t sym_pc = {
+			.type = SYMBOL_LABEL,
+			.value = state->PC,
+			.name = "$"
+		};
+		list_add(state->equates, &sym_pc);
 		result = evaluate_expression(expression, state->equates, &error, &symbol);
 		free_expression(expression);
+		state->equates->length = len;
 	}
 	if (error == EXPRESSION_BAD_SYMBOL) {
 		ERROR(ERROR_UNKNOWN_SYMBOL, state->column, symbol);

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -760,7 +760,6 @@ int handle_equ(struct assembler_state *state, char **argv, int argc) {
 		};
 		list_add(state->equates, &sym_pc);
 		result = evaluate_expression(expression, state->equates, &error, &symbol);
-		free_expression(expression);
 		state->equates->length = len;
 	}
 	if (error == EXPRESSION_BAD_SYMBOL) {
@@ -778,6 +777,7 @@ int handle_equ(struct assembler_state *state, char **argv, int argc) {
 		list_add(state->current_area->symbols, sym);
 		scas_log(L_DEBUG, "Added equate '%s' with value 0x%08X", sym->name, sym->value);
 	}
+	free_expression(expression);
 	return 1;
 }
 

--- a/common/list.c
+++ b/common/list.c
@@ -49,12 +49,13 @@ void list_insert(list_t *list, int index, void *item) {
 
 void list_del(list_t *list, int index) {
 	list->length--;
-	memmove(&list->items[index], &list->items[index + 1], sizeof(void*) * (list->length - index));
+	if (index != list->length) {
+		memmove(&list->items[index], &list->items[index + 1], sizeof(void*) * (list->length - index));
+	}
 }
 
 void list_cat(list_t *list, list_t *source) {
-	int i;
-	for (i = 0; i < source->length; ++i) {
+	for (int i = 0; i < source->length; ++i) {
 		list_add(list, source->items[i]);
 	}
 }

--- a/include/assembler.h
+++ b/include/assembler.h
@@ -50,6 +50,7 @@ struct assembler_state {
 
 object_t *assemble(FILE *file, const char *file_name, assembler_settings_t *settings);
 void transform_local_labels(tokenized_expression_t *expression, const char *last_global_label);
+void transform_relative_labels(tokenized_expression_t *expression, int last_relative_label, const char *const file_name);
 void macro_free(macro_t *macro);
 	
 #endif

--- a/linker/linker.c
+++ b/linker/linker.c
@@ -226,10 +226,10 @@ void link_objects(FILE *output, list_t *objects, linker_settings_t *settings) {
 		scas_log(L_DEBUG, "Generating symbol file '%s'", scas_runtime.symbol_file);
 		FILE *symfile = fopen(scas_runtime.symbol_file, "w");
 		for (int i = 0; i < symbols->length; i++) {
-    			symbol_t *symbol = symbols->items[i];
-    			if (symbol->type == SYMBOL_LABEL && symbol->exported) {
-	    			fprintf(symfile, ".equ %s, %lu\n", symbol->name, symbol->value);
-    			}
+			symbol_t *symbol = symbols->items[i];
+			if (symbol->type == SYMBOL_LABEL && symbol->exported && !strchr(symbol->name, '@')) {
+				fprintf(symfile, ".equ %s 0x%lX\n", symbol->name, symbol->value);
+			}
 		}
 		fflush(symfile);
 		fclose(symfile);

--- a/scas/main.c
+++ b/scas/main.c
@@ -324,6 +324,7 @@ int main(int argc, char **argv) {
 		}
 		fclose(out);
 	}
+	
 	if (errors->length != 0) {
 		int i;
 		for (i = 0; i < errors->length; ++i) {


### PR DESCRIPTION
- [x] Fix building the kernel
  - [x] Else within false conditional results in incorrect evaluation
  - [x] Fix edge cases in macro support
  - [x] Relative label support
    - [x] Backwards relative labels
  - [x] exec directive, or alternative
    -  KnightOS/kernel#195
  - [x] Fix undefinitions
  - [x] Add support for `%bbbbb` binary form
  - [x] Implement `.echo`
      - [ ] Actually print out echoed information instead of discarding it
  - [x] Fix local label translation
  - [x] Forwards lookup of local labels within .dw
  - [x] Expose equates to linker
  - [x] Symbol files
  - [x] ~~Listing files?~~ Not needed for 1.0 release.
  - [x] Get page 0 building
    - [x] Byte-wise comparison of output against sass'
  - [x] Get page 1 building
    - [x] Byte-wise comparison of output against sass'
  - [x] Get page 2 building
    - [ ] Byte-wise comparison of output against sass'
  - [x] Get page `boot` building
  - [x] Get page `priviledged` building
- [x] Add CI to ensure no new leaks or compiler warnings are added
- [x] Fix all memory leaks when assembling kernel
  - [x] Fix all memory leaks when building 00.bin
  - [x] Fix all memory errors when building 00.bin
  - [x] Fix all memory leaks when building 01.bin
  - [x] Fix all memory errors when building 01.bin
  - [x] Fix all memory leaks when building 02.bin
  - [x] Fix all memory errors when building 02.bin
  - [x] Fix all memory leaks when building boot page
  - [x] Fix all memory errors when building boot page
  - [x] Fix all memory leaks when building privledged page
  - [x] Fix all memory errors when building priviledged page
- [x] Fix all compiler warnings
- [x] Testing
