### PR TITLE
Fix memory leaks and compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 2.8.5)
 
 project(scas C)
 set(CMAKE_C_STANDARD 99)
-# Long term goal: add -Werror
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -Werror")
 
 if(WIN32)
     set(CMAKE_C_FLAGS "-Wl,--allow-multiple-definition")

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -88,6 +88,7 @@ void transform_relative_labels(tokenized_expression_t *expression, int last_rela
 		const char *fmtstring = "relative@%d";
 		int len = log10_u64(relative_label);
 		const int size = strlen(fmtstring) - 2 + len + 1;
+		free(token->symbol);
 		token->symbol = malloc(size);
 		if (snprintf(token->symbol, size, fmtstring, relative_label) != size - 1) {
     			scas_log(L_ERROR, "UNREACHABLE");

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -107,6 +107,7 @@ void transform_relative_labels(tokenized_expression_t *expression, int last_rela
 }
 
 int try_empty_line(struct assembler_state *state, char **line) {
+	(void)state;
 	return strlen(*line) == 0;
 }
 
@@ -349,13 +350,13 @@ int try_add_label(struct assembler_state *state, char **line) {
 	} else if (strncmp("_", *line, i) == 0) {
 		const char *fmtstring = "relative@%d";
 		int len = log10_u64(state->last_relative_label);
-		const size = strlen(fmtstring) - 2 + len + 1;
+		const int size = strlen(fmtstring) - 2 + len + 1;
 		sym->name = malloc(size);
 		if (!sym->name) {
 			scas_log(L_ERROR, "OOM");
 			exit(1);
 		}
-		if (snprintf(sym->name, size, fmtstring, state->last_relative_label++) >= size) {
+		if (snprintf(sym->name, size, fmtstring, state->last_relative_label++) != size - 1) {
 			scas_log(L_ERROR, "Unreachable.");
 			exit(1);
 		}
@@ -541,8 +542,7 @@ int try_split_line(struct assembler_state *state, char **line) {
 		"#define",
 		".define"
 	};
-	int i;
-	for (i = 0; i < sizeof(blacklist) / sizeof(char *); ++i) {
+	for (size_t i = 0; i < sizeof(blacklist) / sizeof(char *); ++i) {
 		if (code_strstr(*line, blacklist[i]) == *line) {
 			return 0;
 		}

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -434,16 +434,12 @@ int try_match_instruction(struct assembler_state *state, char **_line) {
 			if (error == EXPRESSION_BAD_SYMBOL) {
 				if (scas_runtime.options.explicit_import && strcmp(symbol, "$") != 0) {
 					unresolved_symbol_t *unresolved_sym = malloc(sizeof(unresolved_symbol_t));
-					unresolved_sym->name = malloc(strlen(symbol)+1);
-					strcpy(unresolved_sym->name,symbol);
+					unresolved_sym->name = strdup(symbol);
 					unresolved_sym->column = state->column;
 					unresolved_sym->line_number = *(int*)stack_peek(state->line_number_stack);
-					unresolved_sym->line = malloc(strlen(state->line) + 1);
-					strcpy(unresolved_sym->line,state->line);
-					const char *file_name = stack_peek(state->file_name_stack);
-					unresolved_sym->file_name = malloc(strlen(file_name)+1);
-					strcpy(unresolved_sym->file_name,file_name);
-					list_add(state->object->unresolved,unresolved_sym);
+					unresolved_sym->line = strdup(state->line);
+					unresolved_sym->file_name = strdup(stack_peek(state->file_name_stack));
+					list_add(state->object->unresolved, unresolved_sym);
 				}
 				scas_log(L_DEBUG, "Postponing evaluation of '%s' to linker", ref->value_provided);
 				late_immediate_t *late_imm = malloc(sizeof(late_immediate_t));

--- a/assembler/assembler.c
+++ b/assembler/assembler.c
@@ -91,8 +91,8 @@ void transform_relative_labels(tokenized_expression_t *expression, int last_rela
 		free(token->symbol);
 		token->symbol = malloc(size);
 		if (snprintf(token->symbol, size, fmtstring, relative_label) != size - 1) {
-    			scas_log(L_ERROR, "UNREACHABLE");
-    			exit(1);
+			scas_log(L_ERROR, "UNREACHABLE");
+			exit(1);
 		}
 
 		scas_log(L_DEBUG, "Transformed relative label with offset %d to %s, %d - %d", offset, token->symbol, i, j);
@@ -242,8 +242,8 @@ int try_expand_macro(struct assembler_state *state, char **line) {
 			for (k = 0; k < macro->parameters->length; ++k) {
 				char *p = macro->parameters->items[k];
 				if (!strcmp(p, "")) {
-    					scas_log(L_ERROR, "Attempt to insert '%s' where no parameter is expected...", (char*)userparams->items[k]);
-    					break;
+					scas_log(L_ERROR, "Attempt to insert '%s' where no parameter is expected...", (char*)userparams->items[k]);
+					break;
 				}
 				scas_log(L_DEBUG, "Replacing '%s' with '%s' for line '%s'", 
 					p, (char *)userparams->items[k], (char *)newlines->items[j]);
@@ -450,7 +450,7 @@ int try_match_instruction(struct assembler_state *state, char **_line) {
 					late_imm->expression = expression;
 					list_add(state->current_area->late_immediates, late_imm);
 				} else {
-    					free_expression(expression);
+					free_expression(expression);
 					if (imm->type == IMM_TYPE_RELATIVE) {
 						result = result - ((state->PC + scas_runtime.options.origin)
 							+ (match->instruction->width / 8));
@@ -616,8 +616,8 @@ object_t *assemble(FILE *file, const char *file_name, assembler_settings_t *sett
 					source_map_entry_t *entry = map->entries->items[map->entries->length - 1];
 					entry->length = state.PC - entry->address;
 					if (entry->length == 0) {
-    						free(entry->source_code);
-    						free(entry);
+						free(entry->source_code);
+						free(entry);
 						list_del(map->entries, map->entries->length - 1);
 					}
 				}
@@ -691,17 +691,17 @@ object_t *assemble(FILE *file, const char *file_name, assembler_settings_t *sett
 	stack_free(state.line_number_stack);
 	list_free(state.extra_lines);
 	for (int i = 0; i < state.macros->length; i += 1) {
-    		macro_t *macro = state.macros->items[i];
-    		list_free(macro->parameters);
-    		free_flat_list(macro->macro_lines);
-    		free(macro->name);
-    		free(macro);
+		macro_t *macro = state.macros->items[i];
+		list_free(macro->parameters);
+		free_flat_list(macro->macro_lines);
+		free(macro->name);
+		free(macro);
 	}
 	list_free(state.macros);
 	for (int i = 0; i < state.equates->length; i += 1) {
-    		symbol_t *sym = (symbol_t*)state.equates->items[i];
-    		free(sym->name);
-    		free(sym);
+		symbol_t *sym = (symbol_t*)state.equates->items[i];
+		free(sym->name);
+		free(sym);
 	}
 	list_free(state.equates);
 	stack_free(state.source_map_stack);

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -732,6 +732,7 @@ int handle_equ(struct assembler_state *state, char **argv, int argc) {
 		return 1;
 	} else {
 		result = evaluate_expression(expression, state->equates, &error, &symbol);
+		free_expression(expression);
 	}
 	if (error == EXPRESSION_BAD_SYMBOL) {
 		ERROR(ERROR_UNKNOWN_SYMBOL, state->column, symbol);
@@ -747,7 +748,6 @@ int handle_equ(struct assembler_state *state, char **argv, int argc) {
 		list_add(state->equates, sym);
 		scas_log(L_DEBUG, "Added equate '%s' with value 0x%08X", sym->name, sym->value);
 	}
-	free_expression(expression);
 	return 1;
 }
 
@@ -923,6 +923,7 @@ int handle_if(struct assembler_state *state, char **argv, int argc) {
 		return 1;
 	} else {
 		result = evaluate_expression(expression, state->equates, &error, &symbol);
+		free_expression(expression);
 	}
 	if (error == EXPRESSION_BAD_SYNTAX) {
 		ERROR(ERROR_INVALID_SYNTAX, state->column);
@@ -1239,6 +1240,7 @@ int handle_org(struct assembler_state *state, char **argv, int argc) {
 		return 1;
 	} else {
 		result = evaluate_expression(expression, state->equates, &error, &symbol);
+		free_expression(expression);
 	}
 	if (error == EXPRESSION_BAD_SYMBOL) {
 		ERROR(ERROR_UNKNOWN_SYMBOL, state->column, symbol);

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -1474,8 +1474,8 @@ int try_handle_directive(struct assembler_state *state, char **line) {
 		indent_log();
 		int ret = d->function(state, argv, argc);
 		deindent_log();
-		while (argc--) {
-			free(argv[argc]);
+		for (int i = 0; i < argc; i += 1) {
+    			free(argv[i]);
 		}
 		free(argv);
 		return ret;

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -226,6 +226,7 @@ int handle_db(struct assembler_state *state, char **argv, int argc) {
 			uint64_t result;
 			char *symbol;
 			tokenized_expression_t *expression = parse_expression(argv[i]);
+			bool keep = false;
 
 			if (expression == NULL) {
 				error = EXPRESSION_BAD_SYNTAX;
@@ -263,6 +264,7 @@ int handle_db(struct assembler_state *state, char **argv, int argc) {
 				late_imm->width = 8;
 				late_imm->type = IMM_TYPE_ABSOLUTE;
 				late_imm->expression = expression;
+				keep = true;
 				list_add(state->current_area->late_immediates, late_imm);
 				*state->instruction_buffer = 0;
 			} else if (error == EXPRESSION_BAD_SYNTAX) {
@@ -277,6 +279,9 @@ int handle_db(struct assembler_state *state, char **argv, int argc) {
 			++olen;
 			append_to_area(state->current_area, state->instruction_buffer, 1);
 			++state->PC;
+			if (!keep) {
+	    			free_expression(expression);
+			}
 		}
 	}
 	if (!state->expanding_macro) {
@@ -740,6 +745,7 @@ int handle_equ(struct assembler_state *state, char **argv, int argc) {
 		list_add(state->equates, sym);
 		scas_log(L_DEBUG, "Added equate '%s' with value 0x%08X", sym->name, sym->value);
 	}
+	free_expression(expression);
 	return 1;
 }
 
@@ -805,6 +811,7 @@ int handle_fill(struct assembler_state *state, char **argv, int argc) {
 			buffer = calloc(size, sizeof(uint8_t));
 		}
 		append_to_area(state->current_area, buffer, sizeof(uint8_t) * size);
+		free(buffer);
 		state->PC += size;
 	}
 	return 1;

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -68,6 +68,9 @@ char *join_args(char **argv, int argc) {
 }
 
 int handle_nop(struct assembler_state *state, char **argv, int argc) {
+	(void)state;
+	(void)argv;
+	(void)argc;
 	return 1;
 }
 
@@ -407,7 +410,7 @@ int handle_define(struct assembler_state *state, char **argv, int argc) {
 		*location = _;
 		++location;
 	}
-	if ((strlen(argv[0]) + 1) == (location - argv[0])) { /* End of string? */
+	if ((strlen(argv[0]) + 1) == (size_t)(location - argv[0])) { /* End of string? */
 		list_add(define->macro_lines, "1"); /* default value is 1 */
 	} else {
 		while (isspace(*location)) {
@@ -568,6 +571,7 @@ char **printf_argv;
 int printf_argc;
 
 static uintmax_t printf_arg(size_t size) {
+	(void)size;
 	// TODO: support strings?
 
 	int error;
@@ -662,6 +666,7 @@ int handle_elseif(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_else(struct assembler_state *state, char **argv, int argc) {
+	(void)argv;
 	if (argc != 0) {
 		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "else expects 0 arguments");
 		return 1;
@@ -677,6 +682,7 @@ int handle_else(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_end(struct assembler_state *state, char **argv, int argc) {
+	(void)argv;
 	if (argc != 0) {
 		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "end expects 0 arguments");
 		return 1;
@@ -690,6 +696,7 @@ int handle_end(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_endif(struct assembler_state *state, char **argv, int argc) {
+	(void)argv;
 	if (argc != 0) {
 		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "endif expects 0 arguments");
 		return 1;
@@ -808,6 +815,7 @@ int handle_fill(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_even(struct assembler_state *state, char **argv, int argc) {
+	(void)argv;
 	if (argc != 0) {
 		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "even expects 0 arguments");
 		return 1;
@@ -834,7 +842,7 @@ int handle_function(struct assembler_state *state, char **argv, int argc) {
 		meta->value_length = sizeof(uint32_t);
 		*(uint32_t *)meta->value = 0;
 	}
-	list_t *functions = decode_function_metadata(state->current_area, meta->value, meta->value_length);
+	list_t *functions = decode_function_metadata(state->current_area, meta->value);
 	function_metadata_t *new_function = malloc(sizeof(function_metadata_t));
 
 	new_function->name = malloc(strlen(argv[0]) + 1);
@@ -1097,6 +1105,7 @@ int handle_include(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_list(struct assembler_state *state, char **argv, int argc) {
+	(void)argv;
 	if (argc != 0) {
 		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "list expects 0 arguments");
 		return 1;
@@ -1107,6 +1116,9 @@ int handle_list(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_map(struct assembler_state *state, char **argv, int argc) {
+	if (argc != 3) {
+		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "map expects three arguments");
+	}
 	// .map filename, lineno, code
 	free(((source_map_t *)stack_peek(state->source_map_stack))->file_name);
 	((source_map_t*)stack_peek(state->source_map_stack))->file_name = 
@@ -1156,7 +1168,7 @@ int handle_macro(struct assembler_state *state, char **argv, int argc) {
 				return 1;
 				// TODO: Free everything
 			}
-			else if (end == location && end == ')') {
+			else if (end == location && *end == ')') {
     				// No parameters
     				break;
 			}
@@ -1180,6 +1192,7 @@ int handle_macro(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_nolist(struct assembler_state *state, char **argv, int argc) {
+	(void)argv;
 	if (argc != 0) {
 		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "nolist expects 0 arguments");
 		return 1;
@@ -1190,6 +1203,7 @@ int handle_nolist(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_odd(struct assembler_state *state, char **argv, int argc) {
+	(void)argv;
 	if (argc != 0) {
 		ERROR(ERROR_INVALID_DIRECTIVE, state->column, "odd expects 0 arguments");
 		return 1;
@@ -1231,6 +1245,8 @@ int handle_org(struct assembler_state *state, char **argv, int argc) {
 }
 
 int handle_optsdcc(struct assembler_state *state, char **argv, int argc) {
+	(void)argv;
+	(void)argc;
 	// For now this is a hack to turn off automatic source maps
 	state->auto_source_maps = false;
 	return 1;
@@ -1310,7 +1326,7 @@ int directive_compare(const void *_a, const void *_b) {
 	return strcasecmp(a->match, b->match);
 }
 
-static struct directive nop = { "!", handle_nop };
+static struct directive nop = { "!", handle_nop, 0 };
 struct directive *find_directive(struct directive dirs[], int l, char *line) {
 	if (line[1] == '!') {
 		return &nop;

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -750,7 +750,7 @@ int handle_fill(struct assembler_state *state, char **argv, int argc) {
 	}
 	int error;
 	uint16_t size;
-	uint8_t value;
+	uint8_t value = 0;
 	char *symbol;
 	tokenized_expression_t *expression = parse_expression(argv[0]);
 	if (expression == NULL) {
@@ -793,9 +793,6 @@ int handle_fill(struct assembler_state *state, char **argv, int argc) {
 				}
 				value = result & 0xFF;
 			}
-		}
-		else {
-			value = 0;
 		}
 		uint8_t *buffer;
 		if (value != 0) {

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -280,7 +280,7 @@ int handle_db(struct assembler_state *state, char **argv, int argc) {
 			append_to_area(state->current_area, state->instruction_buffer, 1);
 			++state->PC;
 			if (!keep) {
-	    			free_expression(expression);
+				free_expression(expression);
 			}
 		}
 	}
@@ -558,7 +558,7 @@ int handle_dw(struct assembler_state *state, char **argv, int argc) {
 			}
 		}
 		if (!keep) {
-    			free_expression(expression);
+			free_expression(expression);
 		}
 		append_to_area(state->current_area, state->instruction_buffer, 2);
 		state->PC += 2;
@@ -1177,8 +1177,8 @@ int handle_macro(struct assembler_state *state, char **argv, int argc) {
 				// TODO: Free everything
 			}
 			else if (end == location && *end == ')') {
-    				// No parameters
-    				break;
+				// No parameters
+				break;
 			}
 			char *parameter = malloc(end - location + 1);
 			strncpy(parameter, location, end - location);
@@ -1476,7 +1476,7 @@ int try_handle_directive(struct assembler_state *state, char **line) {
 		int ret = d->function(state, argv, argc);
 		deindent_log();
 		for (int i = 0; i < argc; i += 1) {
-    			free(argv[i]);
+			free(argv[i]);
 		}
 		free(argv);
 		return ret;

--- a/assembler/directives.c
+++ b/assembler/directives.c
@@ -528,8 +528,7 @@ int handle_dw(struct assembler_state *state, char **argv, int argc) {
 				unresolved_sym->line = malloc(strlen(state->line) + 1);
 				strcpy(unresolved_sym->line, state->line);
 				const char *file_name = stack_peek(state->file_name_stack);
-				unresolved_sym->file_name = malloc(sizeof(file_name) + 1);
-				strcpy(unresolved_sym->file_name, file_name);
+				unresolved_sym->file_name = strdup(file_name);
 				list_add(state->object->unresolved, unresolved_sym);
 			}
 

--- a/assembler/privatize.c
+++ b/assembler/privatize.c
@@ -20,8 +20,7 @@ void rename_symbol(area_t *a, const char *original, const char *new) {
 			if (tok->type == SYMBOL) {
 				if (strcasecmp(tok->symbol, original) == 0) {
 					free(tok->symbol);
-					tok->symbol = malloc(strlen(new) + 1);
-					strcpy(tok->symbol, new);
+					tok->symbol = strdup(new);
 				}
 			}
 		}

--- a/assembler/privatize.c
+++ b/assembler/privatize.c
@@ -32,23 +32,20 @@ void rename_symbol(area_t *a, const char *original, const char *new) {
 			function_metadata_t *func = functions->items[i];
 			if (strcasecmp(func->name, original) == 0) {
 				free(func->name);
-				func->name = malloc(strlen(new) + 1);
-				strcpy(func->name, new);
+				func->name = strdup(new);
 			}
 			if (strcasecmp(func->start_symbol, original) == 0) {
 				free(func->start_symbol);
-				func->start_symbol = malloc(strlen(new) + 1);
-				strcpy(func->start_symbol, new);
+				func->start_symbol = strdup(new);
 			}
 			if (strcasecmp(func->end_symbol, original) == 0) {
 				free(func->end_symbol);
-				func->end_symbol = malloc(strlen(new) + 1);
-				strcpy(func->end_symbol, new);
+				func->end_symbol = strdup(new);
 			}
 		}
-		meta->value = encode_function_metadata(functions, &meta->value_length);
+		char *value = encode_function_metadata(functions, &meta->value_length);
 		list_free(functions);
-		set_area_metadata(a, "scas.functions", meta->value, meta->value_length);
+		set_area_metadata(a, "scas.functions", value, meta->value_length);
 	}
 }
 
@@ -89,12 +86,11 @@ void privatize_area(object_t *o, area_t *a, list_t *exports) {
 				1 +
 				strlen(checksum) +
 				1);
-			strcpy(new_name, s->name);
-			strcat(new_name, "@");
-			strcat(new_name, checksum);
+			char *marker = strcpy(new_name, s->name);
+			marker = strcat(marker, "@");
+			marker = strcat(marker, checksum);
 			scas_log(L_DEBUG, "Renaming private symbol '%s' to '%s'", s->name, new_name);
-			int j;
-			for (j = 0; j < o->areas->length; ++j) {
+			for (int j = 0; j < o->areas->length; ++j) {
 				area_t *_a = o->areas->items[j];
 				rename_symbol(_a, s->name, new_name);
 			}

--- a/assembler/privatize.c
+++ b/assembler/privatize.c
@@ -28,7 +28,7 @@ void rename_symbol(area_t *a, const char *original, const char *new) {
 	}
 	metadata_t *meta = get_area_metadata(a, "scas.functions");
 	if (meta != NULL) {
-		list_t *functions = decode_function_metadata(a, meta->value, meta->value_length);
+		list_t *functions = decode_function_metadata(a, meta->value);
 		for (i = 0; i < functions->length; ++i) {
 			function_metadata_t *func = functions->items[i];
 			if (strcasecmp(func->name, original) == 0) {

--- a/common/errors.c
+++ b/common/errors.c
@@ -140,8 +140,7 @@ void add_error_from_map(list_t *errors, int code, list_t *maps, uint64_t address
 	if (found) {
 		error->line_number = entry->line_number;
 		error->file_name = map->file_name;
-		error->line = malloc(strlen(entry->source_code) + 1);
-		strcpy(error->line, entry->source_code);
+		error->line = strdup(entry->source_code);
 	} else {
 		error->line_number = 0;
 		error->file_name = NULL;

--- a/common/errors.c
+++ b/common/errors.c
@@ -44,10 +44,8 @@ void add_error(list_t *errors, int code, size_t line_number, const char *line,
 	error_t *error = malloc(sizeof(error_t));
 	error->code = code;
 	error->line_number = line_number;
-	error->file_name = malloc(strlen(file_name) + 1);
-	strcpy(error->file_name, file_name);
-	error->line = malloc(strlen(line) + 1);
-	strcpy(error->line, line);
+	error->file_name = strdup(file_name);
+	error->line = strdup(line);
 	error->column = column;
 
 	const char *fmt = get_error_string(error);
@@ -139,7 +137,7 @@ void add_error_from_map(list_t *errors, int code, list_t *maps, uint64_t address
 	error->message = buf;
 	if (found) {
 		error->line_number = entry->line_number;
-		error->file_name = map->file_name;
+		error->file_name = strdup(map->file_name);
 		error->line = strdup(entry->source_code);
 	} else {
 		error->line_number = 0;

--- a/common/expression.c
+++ b/common/expression.c
@@ -85,8 +85,7 @@ tokenized_expression_t *fread_tokenized_expression(FILE *f) {
 	fread(&len, sizeof(uint32_t), 1, f);
 	tokenized_expression_t *expression = malloc(sizeof(tokenized_expression_t));
 	expression->tokens = create_list();
-	int i;
-	for (i = 0; i < len; ++i) {
+	for (uint32_t i = 0; i < len; ++i) {
 		expression_token_t *token = malloc(sizeof(expression_token_t));
 		token->type = fgetc(f);
 		switch (token->type) {
@@ -239,8 +238,7 @@ expression_token_t *parse_digit(const char **string) {
 }
 
 expression_token_t *parse_operator(const char **string, int is_unary) {
-	int i;
-	for (i = 0; i < sizeof(operators) / sizeof(operator_t); i++) {
+	for (size_t i = 0; i < sizeof(operators) / sizeof(operator_t); i++) {
 		operator_t op = operators[i];
 		if (op.is_unary == is_unary && strncmp(op.operator, *string, strlen(op.operator)) == 0) {
 			expression_token_t *exp = malloc(sizeof(expression_token_t));
@@ -283,13 +281,13 @@ void free_expression(tokenized_expression_t *expression) {
 
 // Based on shunting-yard
 tokenized_expression_t *parse_expression(const char *str) {
-	char *operator_cache = malloc(sizeof(operators) / sizeof(operator_t) + 1);
-	int i;
-	for (i = 0; i < sizeof(operators) / sizeof(operator_t); i++) {
+	const size_t op_count = sizeof(operators) / sizeof(operator_t);
+	char *operator_cache = malloc(op_count + 1);
+	for (size_t i = 0; i < op_count; i++) {
 		operator_t op = operators[i];
 		operator_cache[i] = op.operator[0];
 	}
-	operator_cache[i] = 0;
+	operator_cache[op_count] = 0;
 
 	int tokenizer_state = STATE_OPERATOR;
 	tokenized_expression_t *list = malloc(sizeof(tokenized_expression_t));

--- a/common/expression.c
+++ b/common/expression.c
@@ -275,14 +275,14 @@ enum {
 };
 
 void free_expression(tokenized_expression_t *expression) {
-    	for (int i = 0; i < expression->tokens->length; i += 1) {
-        	free_expression_token((expression_token_t*)expression->tokens->items[i]);
-    	}
-    	list_free(expression->tokens);
-    	if (expression->symbols) {
-	    	free_flat_list(expression->symbols);
-    	}
-    	free(expression);
+	for (int i = 0; i < expression->tokens->length; i += 1) {
+		free_expression_token((expression_token_t*)expression->tokens->items[i]);
+	}
+	list_free(expression->tokens);
+	if (expression->symbols) {
+		free_flat_list(expression->symbols);
+	}
+	free(expression);
 }
 
 // Based on shunting-yard

--- a/common/expression.c
+++ b/common/expression.c
@@ -114,8 +114,7 @@ uint64_t evaluate_expression(tokenized_expression_t *expression, list_t
 	uint64_t res = 0;
 	*error = 0;
 
-	int i;
-	for (i = 0; i < expression->tokens->length; ++i) {
+	for (int i = 0; i < expression->tokens->length; ++i) {
 		expression_token_t *token = expression->tokens->items[i];
 		switch (token->type) {
 			case SYMBOL:
@@ -123,13 +122,12 @@ uint64_t evaluate_expression(tokenized_expression_t *expression, list_t
 				resolved->type = NUMBER;
 				resolved->number = 0;
 
-				int found = 0;
-				int j;
-				for (j = 0; j < symbols->length; ++j) {
+				bool found = false;
+				for (int j = 0; j < symbols->length; ++j) {
 					symbol_t *sym = symbols->items[j];
 					if (strcasecmp(sym->name, token->symbol) == 0) {
 						resolved->number = sym->value;
-						found = 1;
+						found = true;
 						break;
 					}
 				}

--- a/common/expression.c
+++ b/common/expression.c
@@ -213,6 +213,7 @@ expression_token_t *parse_digit(const char **string) {
 				expression_token_t *expr = malloc(sizeof(expression_token_t));
 				expr->type = NUMBER;
 				expr->number = (uint64_t)temp[1];
+				free(temp);
 				*string = end + 1;
 				return expr;
 			}

--- a/common/expression.c
+++ b/common/expression.c
@@ -85,6 +85,7 @@ tokenized_expression_t *fread_tokenized_expression(FILE *f) {
 	fread(&len, sizeof(uint32_t), 1, f);
 	tokenized_expression_t *expression = malloc(sizeof(tokenized_expression_t));
 	expression->tokens = create_list();
+	expression->symbols = NULL;
 	for (uint32_t i = 0; i < len; ++i) {
 		expression_token_t *token = malloc(sizeof(expression_token_t));
 		token->type = fgetc(f);
@@ -278,7 +279,9 @@ void free_expression(tokenized_expression_t *expression) {
         	free_expression_token((expression_token_t*)expression->tokens->items[i]);
     	}
     	list_free(expression->tokens);
-    	free_flat_list(expression->symbols);
+    	if (expression->symbols) {
+	    	free_flat_list(expression->symbols);
+    	}
     	free(expression);
 }
 

--- a/common/expression.c
+++ b/common/expression.c
@@ -274,7 +274,13 @@ enum {
 };
 
 void free_expression(tokenized_expression_t *expression) {
+    	for (int i = 0; i < expression->tokens->length; i += 1) {
+        	free_expression_token((expression_token_t*)expression->tokens->items[i]);
+    	}
     	list_free(expression->tokens);
+    	for (int i = 0; i < expression->symbols->length; i += 1) {
+        	free_expression_token((expression_token_t*)expression->symbols->items[i]);
+    	}
     	list_free(expression->symbols);
     	free(expression);
 }
@@ -314,7 +320,7 @@ tokenized_expression_t *parse_expression(const char *str) {
 			expr = parse_digit(&current);
 			if (expr == NULL) {
 				expr = parse_symbol(&current);
-				list_add(list->symbols, expr->symbol);
+				list_add(list->symbols, strdup(expr->symbol));
 			}
 			tokenizer_state = STATE_VALUE;
 		} else if (*current == '(') {
@@ -370,7 +376,7 @@ tokenized_expression_t *parse_expression(const char *str) {
 				goto exit;
 			}
 			expr = parse_symbol(&current);
-			list_add(list->symbols, expr->symbol);
+			list_add(list->symbols, strdup(expr->symbol));
 			tokenizer_state = STATE_VALUE;
 		}
 
@@ -412,7 +418,9 @@ exit:
 }
 
 void free_expression_token(expression_token_t *token) {
-	free(token->symbol);
+	if (token->type == SYMBOL) {
+		free(token->symbol);
+	}
 	free(token);
 }
 

--- a/common/functions.c
+++ b/common/functions.c
@@ -78,11 +78,9 @@ void mark_precious(list_t *functions, late_immediate_t *imm, object_t *object, i
 
 void mark_dependencies_precious(function_metadata_t *parent, list_t *functions, object_t *object) {
 	scas_log(L_DEBUG, "Marking dependencies of %s as precious", parent->name);
-	int i;
-	for (i = 0; i < object->areas->length; ++i) {
+	for (int i = 0; i < object->areas->length; ++i) {
 		area_t *area = object->areas->items[i];
-		int j;
-		for (j = 0; j < area->late_immediates->length; ++j) {
+		for (int j = 0; j < area->late_immediates->length; ++j) {
 			late_immediate_t *imm = area->late_immediates->items[j];
 			if (imm->base_address >= parent->start_address && imm->base_address <= parent->end_address) {
 				mark_precious(functions, imm, object, 1);
@@ -141,7 +139,6 @@ void remove_unused_functions(object_t *object) {
 			mark_dependencies_precious(func, functions, object);
 		}
 	}
-	qsort(functions->items, functions->length, sizeof(function_metadata_t *), compare_functions);
 	for (i = 0; i < functions->length; ++i) {
 		function_metadata_t *func = functions->items[i];
 		if (!func->precious) {

--- a/common/functions.c
+++ b/common/functions.c
@@ -105,7 +105,7 @@ void remove_unused_functions(object_t *object) {
 		area_t *area = object->areas->items[i];
 		metadata_t *meta = get_area_metadata(area, "scas.functions");
 		if (meta) {
-			list_cat(functions, decode_function_metadata(area, meta->value, meta->value_length));
+			list_cat(functions, decode_function_metadata(area, meta->value));
 		}
 	}
 	for (i = 0; i < functions->length; ++i) {
@@ -193,7 +193,7 @@ void remove_unused_functions(object_t *object) {
 	list_free(functions);
 }
 
-list_t *decode_function_metadata(area_t *area, char *value, uint64_t value_length) {
+list_t *decode_function_metadata(area_t *area, char *value) {
 	uint32_t total;
 	list_t *result;
 	total = *(uint32_t *)value;
@@ -201,8 +201,7 @@ list_t *decode_function_metadata(area_t *area, char *value, uint64_t value_lengt
 	result = create_list();
 
 	scas_log(L_DEBUG, "Decoding metadata for %d functions", total);
-	int i;
-	for (i = 0; i < total; ++i) {
+	for (uint32_t i = 0; i < total; ++i) {
 		uint32_t len;
 		function_metadata_t *meta = calloc(1, sizeof(function_metadata_t));
 		meta->area = area;

--- a/common/functions.c
+++ b/common/functions.c
@@ -103,7 +103,7 @@ void remove_unused_functions(object_t *object) {
 		area_t *area = object->areas->items[i];
 		metadata_t *meta = get_area_metadata(area, "scas.functions");
 		if (meta) {
-    			list_t *decoded = decode_function_metadata(area, meta->value);
+			list_t *decoded = decode_function_metadata(area, meta->value);
 			list_cat(functions, decoded);
 			list_free(decoded);
 		}
@@ -115,11 +115,11 @@ void remove_unused_functions(object_t *object) {
 		symbol_t *end = get_symbol_by_name(meta->area, meta->end_symbol);
 		if (!start || !end) {
 			scas_log(L_ERROR, "Warning: function %s has unknown start and end symbols", meta->name);
-	    		function_metadata_t *func = functions->items[i];
-	    		free(func->name);
-	    		free(func->start_symbol);
-	    		free(func->end_symbol);
-	    		free(func);
+			function_metadata_t *func = functions->items[i];
+			free(func->name);
+			free(func->start_symbol);
+			free(func->end_symbol);
+			free(func);
 			list_del(functions, i);
 			--i;
 		} else {
@@ -198,11 +198,11 @@ void remove_unused_functions(object_t *object) {
 		}
 	}
 	for (int i = 0; i < functions->length; i++) {
-    		function_metadata_t *func = functions->items[i];
-    		free(func->name);
-    		free(func->start_symbol);
-    		free(func->end_symbol);
-    		free(func);
+		function_metadata_t *func = functions->items[i];
+		free(func->name);
+		free(func->start_symbol);
+		free(func->end_symbol);
+		free(func);
 	}
 	list_free(functions);
 }

--- a/common/functions.c
+++ b/common/functions.c
@@ -209,12 +209,16 @@ void remove_unused_functions(object_t *object) {
 
 list_t *decode_function_metadata(area_t *area, char *value) {
 	uint32_t total;
-	list_t *result;
+	list_t *result = create_list();
 	total = *(uint32_t *)value;
 	value += sizeof(uint32_t);
-	result = create_list();
 
-	scas_log(L_DEBUG, "Decoding metadata for %d functions", total);
+	if (total > 10000) {
+		scas_log(L_ERROR, "More than 10,000 functions detected. This is probably an internal error.");
+		list_free(result);
+		return NULL;
+	}
+	scas_log(L_DEBUG, "Decoding metadata for %d functions", (int)total);
 	for (uint32_t i = 0; i < total; ++i) {
 		uint32_t len;
 		function_metadata_t *meta = calloc(1, sizeof(function_metadata_t));

--- a/common/instructions.c
+++ b/common/instructions.c
@@ -250,8 +250,7 @@ bool handle_line(char *line, instruction_set_t *result) {
 			return false;
 		}
 		else {
-			result->arch = malloc(strlen(line) - 4);
-			strcpy(result->arch, line + 5);
+			result->arch = strdup(line + 5);
 			free(line);
 			return true;
 		}

--- a/common/instructions.c
+++ b/common/instructions.c
@@ -309,6 +309,10 @@ void instruction_set_free(instruction_set_t *set) {
 	for (i = 0; i < set->instructions->length; ++i) {
 		instruction_t *inst = set->instructions->items[i];
 		/* TODO: This leaks a few other things */
+		for (int i = 0; i < inst->operands->length; i += 1) {
+			instruction_operand_t *op = (instruction_operand_t*)inst->operands->items[i];
+			free(op->group);
+		}
 		free_flat_list(inst->operands);
 		free_flat_list(inst->immediate);
 		free(inst->match);

--- a/common/instructions.c
+++ b/common/instructions.c
@@ -128,8 +128,7 @@ bool parse_instruction_line(const char *line, instruction_set_t *set) {
 	inst->immediate = create_list();
 	inst->value = 0;
 	/* Parse match */
-	int i;
-	for (i = 0; i < strlen(inst->match); ++i) {
+	for (size_t i = 0; i < strlen(inst->match); ++i) {
 		if (inst->match[i] == '@') /* Operand */ {
 			char key = inst->match[++i];
 			i += 2; /* Skip key, < */
@@ -193,7 +192,7 @@ bool parse_instruction_line(const char *line, instruction_set_t *set) {
 	while (*value++ != ' ') { }
 	inst->width = 0;
 	int shift = 0;
-	for (i = 0; i < strlen(value); ++i) {
+	for (size_t i = 0; i < strlen(value); ++i) {
 		if (value[i] == ' ' || value[i] == '\t') {
 			continue;
 		}
@@ -240,7 +239,6 @@ bool parse_instruction_line(const char *line, instruction_set_t *set) {
 bool handle_line(char *line, instruction_set_t *result) {
 	int trimmed_start;
 	line = strip_whitespace(line, &trimmed_start);
-	bool return_value;
 	if (line[0] == '\0' || line[0] == '#') {
 		free(line);
 		return true;
@@ -254,6 +252,7 @@ bool handle_line(char *line, instruction_set_t *result) {
 		else {
 			result->arch = malloc(strlen(line) - 4);
 			strcpy(result->arch, line + 5);
+			free(line);
 			return true;
 		}
 	}
@@ -268,6 +267,7 @@ bool handle_line(char *line, instruction_set_t *result) {
 		return val;
 	}
 	fprintf(stderr, "Unrecognized line: %s\n", line);
+	free(line);
 	return false;
 }
 

--- a/common/instructions.c
+++ b/common/instructions.c
@@ -309,6 +309,8 @@ void instruction_set_free(instruction_set_t *set) {
 	for (i = 0; i < set->instructions->length; ++i) {
 		instruction_t *inst = set->instructions->items[i];
 		/* TODO: This leaks a few other things */
+		free_flat_list(inst->operands);
+		free_flat_list(inst->immediate);
 		free(inst->match);
 		free(inst);
 	}

--- a/common/instructions.c
+++ b/common/instructions.c
@@ -321,8 +321,8 @@ void instruction_set_free(instruction_set_t *set) {
 		for (n = 0; n < group->operands->length; ++n) {
 			operand_t *op = group->operands->items[n];
 			free(op->match);
-			free(op);
 		}
+		free_flat_list(group->operands);
 		free(group->name);
 		free(group);
 	}

--- a/common/log.c
+++ b/common/log.c
@@ -56,8 +56,8 @@ void scas_abort(char *format, ...) {
 }
 
 void scas_log(int verbosity, char* format, ...) {
-	if (verbosity <= v) {
-		int c = verbosity;
+	if (verbosity <= v && verbosity >= 0) {
+		size_t c = verbosity;
 		if (c > sizeof(verbosity_colors) / sizeof(char *)) {
 			c = sizeof(verbosity_colors) / sizeof(char *) - 1;
 		}

--- a/common/match.c
+++ b/common/match.c
@@ -37,8 +37,7 @@ char *get_operand_string(instruction_t *inst, int *i, const char *code, int j) {
 	char *end;
 	if (delimiter == '*') {
 		const char *toks = "+- \t"; // Valid delimiters in this scenario
-		int k;
-		for (k = 0; k < strlen(toks); ++k) {
+		for (size_t k = 0; k < strlen(toks); ++k) {
 			end = code_strchr(code + j, toks[k]);
 			if (end) break;
 		}

--- a/common/match.c
+++ b/common/match.c
@@ -60,9 +60,9 @@ char *get_operand_string(instruction_t *inst, int *i, const char *code, int j) {
 }
 
 void match_free(instruction_match_t *match) {
-    list_free(match->immediate_values);
-    list_free(match->operands);
-    free(match);
+	free_flat_list(match->immediate_values);
+	free_flat_list(match->operands);
+	free(match);
 }
 
 instruction_match_t *try_match(instruction_set_t *set, instruction_t *inst, const char *str) {
@@ -146,6 +146,7 @@ instruction_match_t *try_match(instruction_set_t *set, instruction_t *inst, cons
 			operand_t *op = find_operand(group, value);
 			if (op == NULL) {
 				match = 0;
+				free(value);
 				break;
 			}
 			instruction_operand_t *inst_op = find_instruction_operand(inst, key);

--- a/common/match.c
+++ b/common/match.c
@@ -26,7 +26,7 @@ char *get_operand_string(instruction_t *inst, int *i, const char *code, int j) {
 		}
 	}
 	if (delimiter == '\0') {
-    		return strdup(code + j);
+		return strdup(code + j);
 	}
 	const char *significant_delimiters = "%@&^";
 	if (strchr(significant_delimiters, delimiter)) {

--- a/common/match.c
+++ b/common/match.c
@@ -26,9 +26,7 @@ char *get_operand_string(instruction_t *inst, int *i, const char *code, int j) {
 		}
 	}
 	if (delimiter == '\0') {
-		res = malloc(strlen(code + j) + 1);
-		strcpy(res, code + j);
-		return res;
+    		return strdup(code + j);
 	}
 	const char *significant_delimiters = "%@&^";
 	if (strchr(significant_delimiters, delimiter)) {
@@ -60,7 +58,12 @@ char *get_operand_string(instruction_t *inst, int *i, const char *code, int j) {
 }
 
 void match_free(instruction_match_t *match) {
-	free_flat_list(match->immediate_values);
+	for (int i = 0; i < match->immediate_values->length; i += 1) {
+		immediate_ref_t *ref = (immediate_ref_t*)match->immediate_values->items[i];
+		free(ref->value_provided);
+		free(ref);
+	}
+	list_free(match->immediate_values);
 	free_flat_list(match->operands);
 	free(match);
 }

--- a/common/objects.c
+++ b/common/objects.c
@@ -31,6 +31,13 @@ void object_free(object_t *o) {
     		}
 	}
 	list_free(o->areas);
+	for (int i = 0; i < o->unresolved->length; i += 1) {
+		unresolved_symbol_t *u = (unresolved_symbol_t*)o->unresolved->items[i];
+		free(u->name);
+		free(u->line);
+		free(u->file_name);
+		free(u);
+	}
 	list_free(o->unresolved);
 	list_free(o->imports);
 	list_free(o->exports);
@@ -68,6 +75,11 @@ void area_free(area_t *area) {
 	}
 	list_free(area->source_map);
 	list_free(area->symbols);
+	for (int i = 0; i < area->late_immediates->length; i += 1) {
+		late_immediate_t *imm = (late_immediate_t *)area->late_immediates->items[i];
+    		free_expression(imm->expression);
+    		free(imm);
+	}
 	list_free(area->late_immediates);
 	free(area->name);
 	free(area->data);

--- a/common/objects.c
+++ b/common/objects.c
@@ -134,7 +134,8 @@ void set_area_metadata(area_t *area, const char *key, char *value, uint64_t valu
 	newmeta->key = strdup(key);
 	newmeta->value_length = value_length;
 	if (dupe) {
-		newmeta->value = strdup(value);
+		newmeta->value = malloc(value_length);
+		memcpy(newmeta->value, value, value_length);
 	}
 	else {
 		newmeta->value = value;

--- a/common/objects.c
+++ b/common/objects.c
@@ -180,8 +180,7 @@ area_t *read_area(FILE *f) {
 	uint32_t symbols, immediates;
 	fread(&symbols, sizeof(uint32_t), 1, f);
 	uint32_t len;
-	int i;
-	for (i = 0; i < symbols; ++i) {
+	for (uint32_t i = 0; i < symbols; ++i) {
 		symbol_t *sym = malloc(sizeof(symbol_t));
 		sym->exported = fgetc(f);
 		fread(&len, sizeof(uint32_t), 1, f);
@@ -195,7 +194,7 @@ area_t *read_area(FILE *f) {
 	}
 	/* TODO: Imports */
 	fread(&immediates, sizeof(uint32_t), 1, f);
-	for (i = 0; i < immediates; ++i) {
+	for (uint32_t i = 0; i < immediates; ++i) {
 		late_immediate_t *imm = malloc(sizeof(late_immediate_t));
 		imm->type = fgetc(f);
 		imm->width = fgetc(f);
@@ -216,7 +215,7 @@ area_t *read_area(FILE *f) {
 	uint64_t meta_length, meta_key;
 	fread(&meta_length, sizeof(uint64_t), 1, f);
 	scas_log(L_DEBUG, "Reading %d metadata entries", meta_length);
-	for (i = 0; i < (int)meta_length; ++i) {
+	for (uint64_t i = 0; i < meta_length; ++i) {
 		metadata_t *meta = malloc(sizeof(metadata_t));
 		meta_key = fgetc(f);
 		meta->key = malloc(meta_key);
@@ -230,7 +229,7 @@ area_t *read_area(FILE *f) {
 
 	uint64_t fileno, lineno;
 	fread(&fileno, sizeof(uint64_t), 1, f);
-	for (i = 0; i < (int)fileno; ++i) {
+	for (uint64_t i = 0; i < fileno; ++i) {
 		source_map_t *map = malloc(sizeof(source_map_t));
 		map->file_name = read_line(f);
 		map->entries = create_list();
@@ -264,8 +263,7 @@ object_t *freadobj(FILE *f, const char *name) {
 	}
 	uint32_t area_count;
 	fread(&area_count, sizeof(uint32_t), 1, f);
-	int i;
-	for (i = 0; i < area_count; ++i) {
+	for (uint32_t i = 0; i < area_count; ++i) {
 		list_add(o->areas, read_area(f));
 	}
 	return o;

--- a/common/objects.c
+++ b/common/objects.c
@@ -74,6 +74,11 @@ void area_free(area_t *area) {
     		source_map_free((source_map_t*)area->source_map->items[i]);
 	}
 	list_free(area->source_map);
+	for (int i = 0; i < area->symbols->length; i += 1) {
+	    	symbol_t *sym = (symbol_t*)area->symbols->items[i];
+	    	free(sym->name);
+	    	free(sym);
+	}
 	list_free(area->symbols);
 	for (int i = 0; i < area->late_immediates->length; i += 1) {
 		late_immediate_t *imm = (late_immediate_t *)area->late_immediates->items[i];

--- a/common/objects.c
+++ b/common/objects.c
@@ -22,13 +22,13 @@ object_t *create_object() {
 
 void object_free(object_t *o) {
 	for (int i = 0; i < o->areas->length; i += 1) {
-    		area_t *area = (area_t*)o->areas->items[i];
-    		if (o->merged) {
-        		merged_area_free(area);
-    		}
-    		else {
-	    		area_free(area);
-    		}
+		area_t *area = (area_t*)o->areas->items[i];
+		if (o->merged) {
+		merged_area_free(area);
+		}
+		else {
+			area_free(area);
+		}
 	}
 	list_free(o->areas);
 	for (int i = 0; i < o->unresolved->length; i += 1) {
@@ -71,19 +71,19 @@ void merged_area_free(area_t *area) {
 void area_free(area_t *area) {
 	list_free(area->metadata);
 	for (int i = 0; i < area->source_map->length; i += 1) {
-    		source_map_free((source_map_t*)area->source_map->items[i]);
+		source_map_free((source_map_t*)area->source_map->items[i]);
 	}
 	list_free(area->source_map);
 	for (int i = 0; i < area->symbols->length; i += 1) {
-	    	symbol_t *sym = (symbol_t*)area->symbols->items[i];
-	    	free(sym->name);
-	    	free(sym);
+		symbol_t *sym = (symbol_t*)area->symbols->items[i];
+		free(sym->name);
+		free(sym);
 	}
 	list_free(area->symbols);
 	for (int i = 0; i < area->late_immediates->length; i += 1) {
 		late_immediate_t *imm = (late_immediate_t *)area->late_immediates->items[i];
-    		free_expression(imm->expression);
-    		free(imm);
+		free_expression(imm->expression);
+		free(imm);
 	}
 	list_free(area->late_immediates);
 	free(area->name);
@@ -265,8 +265,11 @@ area_t *read_area(FILE *f) {
 
 	uint64_t meta_length, meta_key;
 	fread(&meta_length, sizeof(uint64_t), 1, f);
+	meta_length = (int)meta_length;
 	scas_log(L_DEBUG, "Reading %d metadata entries", meta_length);
 	for (uint64_t i = 0; i < meta_length; ++i) {
+	scas_log(L_DEBUG, "Reading metadata entry %lld of %lld", i, meta_length);
+
 		metadata_t *meta = malloc(sizeof(metadata_t));
 		meta_key = fgetc(f);
 		meta->key = malloc(meta_key);
@@ -280,14 +283,14 @@ area_t *read_area(FILE *f) {
 
 	uint64_t fileno, lineno;
 	fread(&fileno, sizeof(uint64_t), 1, f);
+	fileno = (int)fileno;
 	for (uint64_t i = 0; i < fileno; ++i) {
 		source_map_t *map = malloc(sizeof(source_map_t));
 		map->file_name = read_line(f);
 		map->entries = create_list();
 		fread(&lineno, sizeof(uint64_t), 1, f);
 		scas_log(L_DEBUG, "Reading source map for '%s', %d entries", map->file_name, lineno);
-		int j;
-		for (j = 0; j < (int)lineno; ++j) {
+		for (int j = 0; j < (int)lineno; ++j) {
 			source_map_entry_t *entry = malloc(sizeof(source_map_entry_t));
 			fread(&entry->line_number, sizeof(uint64_t), 1, f);
 			fread(&entry->address, sizeof(uint64_t), 1, f);
@@ -330,9 +333,9 @@ source_map_t *create_source_map(area_t *area, const char *file_name) {
 
 void source_map_free(source_map_t *map) {
 	for (int i = 0; i < map->entries->length; i += 1) {
-    		source_map_entry_t *entry = (source_map_entry_t*)map->entries->items[i];
-    		free(entry->source_code);
-    		free(entry);
+		source_map_entry_t *entry = (source_map_entry_t*)map->entries->items[i];
+		free(entry->source_code);
+		free(entry);
 	}
 	list_free(map->entries);
 	free(map->file_name);

--- a/common/objects.c
+++ b/common/objects.c
@@ -92,8 +92,7 @@ void area_free(area_t *area) {
 }
 
 metadata_t *get_area_metadata(area_t *area, const char *key) {
-	int i;
-	for (i = 0; i < area->metadata->length; ++i) {
+	for (int i = 0; i < area->metadata->length; ++i) {
 		metadata_t *meta = area->metadata->items[i];
 		if (strcmp(meta->key, key) == 0) {
 			return meta;
@@ -269,10 +268,10 @@ area_t *read_area(FILE *f) {
 	scas_log(L_DEBUG, "Reading %d metadata entries", meta_length);
 	for (uint64_t i = 0; i < meta_length; ++i) {
 	scas_log(L_DEBUG, "Reading metadata entry %lld of %lld", i, meta_length);
-
 		metadata_t *meta = malloc(sizeof(metadata_t));
 		meta_key = fgetc(f);
-		meta->key = malloc(meta_key);
+		meta->key = malloc(meta_key + 1);
+		meta->key[meta_key] = 0;
 		fread(meta->key, sizeof(char), meta_key, f);
 		fread(&meta->value_length, sizeof(uint64_t), 1, f);
 		meta->value = malloc(meta->value_length);

--- a/common/objects.c
+++ b/common/objects.c
@@ -118,14 +118,14 @@ void set_area_metadata(area_t *area, const char *key, char *value, uint64_t valu
 	for (int i = 0; i < area->metadata->length; ++i) {
 		metadata_t *meta = area->metadata->items[i];
 		if (strcmp(meta->key, key) == 0) {
-    			free(meta->key);
-    			if (meta->value != value) {
-    				free(meta->value);
-    			}
-    			else {
-        			dupe = false;
-    			}
-    			free(meta);
+			free(meta->key);
+			if (meta->value != value) {
+				free(meta->value);
+			}
+			else {
+				dupe = false;
+			}
+			free(meta);
 			list_del(area->metadata, i);
 			break;
 		}
@@ -137,7 +137,7 @@ void set_area_metadata(area_t *area, const char *key, char *value, uint64_t valu
 		newmeta->value = strdup(value);
 	}
 	else {
-    		newmeta->value = value;
+		newmeta->value = value;
 	}
 	scas_log(L_DEBUG, "Set area metadata '%s' to new value with length %d", newmeta->key, newmeta->value_length);
 	list_add(area->metadata, newmeta);

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -96,8 +96,7 @@ list_t *split_string(const char *str, const char *delims) {
 }
 
 void free_flat_list(list_t *list) {
-	int i;
-	for (i = 0; i < list->length; ++i) {
+	for (int i = 0; i < list->length; ++i) {
 		free(list->items[i]);
 	}
 	list_free(list);

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -77,8 +77,7 @@ char *strip_comments(char *str) {
 
 list_t *split_string(const char *str, const char *delims) {
 	list_t *res = create_list();
-	int i, j;
-	for (i = 0, j = 0; i < strlen(str) + 1; ++i) {
+	for (size_t i = 0, j = 0; i < strlen(str) + 1; ++i) {
 		if (strchr(delims, str[i]) || i == strlen(str)) {
 			if (i - j == 0) {
 				continue;

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -44,8 +44,7 @@ char *strip_whitespace(char *_str, int *trimmed_start) {
 		}
 		_str++;
 	}
-	char *str = malloc(strlen(_str) + 1);
-	strcpy(str, _str);
+	char *str = strdup(_str);
 	free(strold);
 	int i;
 	for (i = 0; str[i] != '\0'; ++i);

--- a/include/functions.h
+++ b/include/functions.h
@@ -15,7 +15,7 @@ typedef struct {
     uint64_t end_address;
 } function_metadata_t;
 
-list_t *decode_function_metadata(area_t *area, char *value, uint64_t value_length);
+list_t *decode_function_metadata(area_t *area, char *value);
 char *encode_function_metadata(list_t *metadata, uint64_t *value_length);
 void remove_unused_functions(object_t *object);
 

--- a/include/merge.h
+++ b/include/merge.h
@@ -7,7 +7,7 @@
 
 object_t *merge_objects(list_t *objects);
 area_t *get_area_by_name(object_t *object, char *name);
-void merge_areas(object_t *merged, object_t *source);
+bool merge_areas(object_t *merged, object_t *source);
 void relocate_area(area_t *area, uint64_t address, bool immediates);
 
 #endif

--- a/include/objects.h
+++ b/include/objects.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 enum {
     SYMBOL_LABEL,
@@ -73,11 +74,14 @@ typedef struct {
     list_t *exports;
     list_t *imports;
     list_t *unresolved;
+    bool merged;
 } object_t;
 
 object_t *create_object();
 void object_free(object_t *object);
 area_t *create_area(const char *name);
+void merged_area_free(area_t *area);
+void area_free(area_t *area);
 metadata_t *get_area_metadata(area_t *area, const char *key);
 void set_area_metadata(area_t *area, const char *key, char *value, uint64_t value_length);
 void append_to_area(area_t *area, uint8_t *data, size_t length);
@@ -87,5 +91,6 @@ void fwriteobj(FILE *file, object_t *object);
 object_t *freadobj(FILE *file, const char *name);
 void add_source_map(source_map_t *map, int line_number, const char *line, uint64_t address, uint64_t length);
 source_map_t *create_source_map(area_t *area, const char *file_name);
+void source_map_free(source_map_t *map);
 
 #endif

--- a/linker/8xp.c
+++ b/linker/8xp.c
@@ -24,8 +24,7 @@ void write_8xp_header(FILE *f, int data_len) {
 
 	/* Comment */
 	fwrite(comment, sizeof(char), strlen(comment), f);
-	int i;
-	for (i = 0; i < 42 - strlen(comment); ++i) {
+	for (size_t i = 0; i < 42 - strlen(comment); ++i) {
 		fputc(' ', f);
 	}
 
@@ -35,6 +34,7 @@ void write_8xp_header(FILE *f, int data_len) {
 }
 
 void write_8xp_data(FILE *f, uint8_t *data, int len) {
+	(void)data;
 	uint16_t const_1 = 0x000D;
 	write_le16(f, const_1);
 
@@ -52,8 +52,7 @@ void write_8xp_data(FILE *f, uint8_t *data, int len) {
 	/* Variable name */
 	fwrite(scas_runtime.options.prog_name_8xp, sizeof(char),
 		strlen(scas_runtime.options.prog_name_8xp), f);
-	int i;
-	for (i = 0; i < 8 - strlen(scas_runtime.options.prog_name_8xp); ++i) {
+	for (size_t i = 0; i < 8 - strlen(scas_runtime.options.prog_name_8xp); ++i) {
 		fputc('\0', f); /* Pad to 8 chars */
 	}
 

--- a/linker/linker.c
+++ b/linker/linker.c
@@ -218,5 +218,6 @@ void link_objects(FILE *output, list_t *objects, linker_settings_t *settings) {
 	settings->write_output(output, final->data, (int)final->data_length);
 	scas_log(L_DEBUG, "Final binary written: %d bytes", ftell(output));
 	object_free(merged);
+	area_free(final);
 	list_free(symbols);
 }

--- a/linker/linker.c
+++ b/linker/linker.c
@@ -217,5 +217,6 @@ void link_objects(FILE *output, list_t *objects, linker_settings_t *settings) {
 	}
 	settings->write_output(output, final->data, (int)final->data_length);
 	scas_log(L_DEBUG, "Final binary written: %d bytes", ftell(output));
+	object_free(merged);
 	list_free(symbols);
 }

--- a/linker/linker.c
+++ b/linker/linker.c
@@ -160,14 +160,13 @@ void link_objects(FILE *output, list_t *objects, linker_settings_t *settings) {
 	list_t *symbols = create_list(); // TODO: Use a hash table
 
 	/* Create a new area for relocatable references */
-	area_t *runtime;
+	area_t *runtime = NULL;
 	if (settings->automatic_relocation) {
 		const char *sym_name = "__scas_relocatable_data";
 		runtime = create_area("__scas_relocatable");
 		symbol_t *sym = malloc(sizeof(symbol_t));
 		sym->type = SYMBOL_LABEL;
-		sym->name = malloc(strlen(sym_name) + 1);
-		strcpy(sym->name, sym_name);
+		sym->name = strdup(sym_name);
 		sym->value = 0;
 		sym->defined_address = 0;
 		sym->exported = 0;
@@ -178,6 +177,11 @@ void link_objects(FILE *output, list_t *objects, linker_settings_t *settings) {
 	}
 
 	object_t *merged = merge_objects(objects);
+	if (!merged) {
+		list_free(symbols);
+		return;
+	}
+
 	area_t *final = create_area("FINAL");
 
 	runtime = get_area_by_name(merged, "__scas_relocatable");

--- a/linker/linker.c
+++ b/linker/linker.c
@@ -87,8 +87,7 @@ void resolve_immediate_values(list_t *symbols, area_t *area, list_t *errors) {
 				}
 			}
 			result = result & mask;
-			int j;
-			for (j = 0; j < imm->width / 8; ++j) {
+			for (size_t j = 0; j < imm->width / 8; ++j) {
 				area->data[imm->address + j] |= (result & 0xFF);
 				result >>= 8;
 			}

--- a/linker/merge.c
+++ b/linker/merge.c
@@ -78,8 +78,16 @@ void merge_areas(object_t *merged, object_t *source) {
 				merged = create_list();
 			}
 			list_cat(merged, decoded);
+			list_free(decoded);
 			uint64_t len;
 			char *merged_metadata = encode_function_metadata(merged, &len);
+			for (int i = 0; i < merged->length; i++) {
+    				function_metadata_t *func = merged->items[i];
+	    			free(func->name);
+	    			free(func->start_symbol);
+	    			free(func->end_symbol);
+			}
+	    		free_flat_list(merged);
 			set_area_metadata(merged_area, "scas.functions", merged_metadata, len);
 		}
 		list_cat(merged_area->source_map, source_area->source_map);

--- a/linker/merge.c
+++ b/linker/merge.c
@@ -52,8 +52,7 @@ void relocate_area(area_t *area, uint64_t address, bool immediates) {
 }
 
 bool merge_areas(object_t *merged, object_t *source) {
-	int i;
-	for (i = 0; i < source->areas->length; ++i) {
+	for (int i = 0; i < source->areas->length; ++i) {
 		area_t *source_area = source->areas->items[i];
 		area_t *merged_area = get_area_by_name(merged, source_area->name);
 		if (merged_area == NULL) {

--- a/linker/merge.c
+++ b/linker/merge.c
@@ -89,6 +89,7 @@ void merge_areas(object_t *merged, object_t *source) {
 object_t *merge_objects(list_t *objects) {
 	scas_log(L_INFO, "Merging %d objects into one", objects->length);
 	object_t *merged = create_object();
+	merged->merged = true;
 	int i;
 	for (i = 0; i < objects->length; ++i) {
 		object_t *o = objects->items[i];

--- a/linker/merge.c
+++ b/linker/merge.c
@@ -70,10 +70,10 @@ void merge_areas(object_t *merged, object_t *source) {
 		metadata_t *new_functions = get_area_metadata(source_area, "scas.functions");
 		metadata_t *old_functions = get_area_metadata(merged_area, "scas.functions");
 		if (new_functions) {
-			list_t *decoded = decode_function_metadata(source_area, new_functions->value, new_functions->value_length);
+			list_t *decoded = decode_function_metadata(source_area, new_functions->value);
 			list_t *merged;
 			if (old_functions) {
-				merged = decode_function_metadata(source_area, old_functions->value, old_functions->value_length);
+				merged = decode_function_metadata(source_area, old_functions->value);
 			} else {
 				merged = create_list();
 			}

--- a/linker/merge.c
+++ b/linker/merge.c
@@ -89,12 +89,12 @@ bool merge_areas(object_t *merged, object_t *source) {
 			uint64_t len;
 			char *merged_metadata = encode_function_metadata(merged, &len);
 			for (int i = 0; i < merged->length; i++) {
-    				function_metadata_t *func = merged->items[i];
-	    			free(func->name);
-	    			free(func->start_symbol);
-	    			free(func->end_symbol);
+				function_metadata_t *func = merged->items[i];
+				free(func->name);
+				free(func->start_symbol);
+				free(func->end_symbol);
 			}
-	    		free_flat_list(merged);
+			free_flat_list(merged);
 			set_area_metadata(merged_area, "scas.functions", merged_metadata, len);
 			free(merged_metadata);
 		}

--- a/scas/main.c
+++ b/scas/main.c
@@ -357,6 +357,9 @@ int main(int argc, char **argv) {
 	scas_log(L_DEBUG, "Exiting with status code %d, cleaning up", ret);
 	list_free(scas_runtime.input_files);
 	free_flat_list(include_path);
+	for (int i = 0; i < objects->length; i += 1) {
+    		object_free((object_t*)objects->items[i]);
+	}
 	list_free(objects);
 	list_free(errors);
 	list_free(warnings);

--- a/scas/main.c
+++ b/scas/main.c
@@ -287,9 +287,9 @@ int main(int argc, char **argv) {
 		out = stdout;
 	} else {
 		out = fopen(scas_runtime.output_file, "w+");
-	}
-	if (!out) {
-		scas_abort("Unable to open '%s' for output.", scas_runtime.output_file);
+		if (!out) {
+			scas_abort("Unable to open '%s' for output.", scas_runtime.output_file);
+		}
 	}
 
 	if ((scas_runtime.jobs & LINK) == LINK) {

--- a/scas/main.c
+++ b/scas/main.c
@@ -311,8 +311,17 @@ int main(int argc, char **argv) {
 	} else {
 		scas_log(L_INFO, "Skipping linking - writing to object file");
 		object_t *merged = merge_objects(objects);
-		fwriteobj(out, merged);
-		fflush(out);
+		if (merged) {
+			fwriteobj(out, merged);
+			object_free(merged);
+			fflush(out);
+		}
+		else {
+			scas_log(L_ERROR, "Failed to merge");
+			if (out != stdout) {
+			remove(scas_runtime.output_file);
+		}
+		}
 		fclose(out);
 	}
 	if (errors->length != 0) {

--- a/scas/main.c
+++ b/scas/main.c
@@ -322,7 +322,9 @@ int main(int argc, char **argv) {
 			fprintf(stderr, "%s:%d:%d: error #%d: %s\n", error->file_name,
 					(int)error->line_number, (int)error->column, error->code,
 					error->message);
-			fprintf(stderr, "%s\n", error->line);
+			if (error->line) {
+				fprintf(stderr, "%s\n", error->line);
+			}
 			if (error->column != 0) {
 				int j;
 				for (j = error->column; j > 0; --j) {
@@ -332,6 +334,11 @@ int main(int argc, char **argv) {
 			} else {
 				fprintf(stderr, "\n");
 			}
+			if (error->line) {
+    				free (error->line);
+			}
+			free(error->message);
+			free(error);
 		}
 		remove(scas_runtime.output_file);
 	}

--- a/scas/main.c
+++ b/scas/main.c
@@ -229,8 +229,8 @@ int main(int argc, char **argv) {
 	validate_scas_runtime();
 	instruction_set_t *instruction_set = find_inst();
 	if (instruction_set == NULL) {
-    		fprintf(stderr, "Failed to load instruction set definition, unable to continue!\n");
-    		return 1;
+		fprintf(stderr, "Failed to load instruction set definition, unable to continue!\n");
+		return 1;
 	}
 	scas_log(L_INFO, "Loaded instruction set: %s", instruction_set->arch);
 	list_t *include_path = split_include_path();
@@ -319,8 +319,8 @@ int main(int argc, char **argv) {
 		else {
 			scas_log(L_ERROR, "Failed to merge");
 			if (out != stdout) {
-			remove(scas_runtime.output_file);
-		}
+				remove(scas_runtime.output_file);
+			}
 		}
 		fclose(out);
 	}
@@ -344,7 +344,7 @@ int main(int argc, char **argv) {
 				fprintf(stderr, "\n");
 			}
 			if (error->line) {
-    				free (error->line);
+				free (error->line);
 			}
 			free(error->file_name);
 			free(error->message);
@@ -375,7 +375,7 @@ int main(int argc, char **argv) {
 	list_free(scas_runtime.input_files);
 	free_flat_list(include_path);
 	for (int i = 0; i < objects->length; i += 1) {
-    		object_free((object_t*)objects->items[i]);
+		object_free((object_t*)objects->items[i]);
 	}
 	list_free(objects);
 	list_free(errors);

--- a/scas/main.c
+++ b/scas/main.c
@@ -337,6 +337,7 @@ int main(int argc, char **argv) {
 			if (error->line) {
     				free (error->line);
 			}
+			free(error->file_name);
 			free(error->message);
 			free(error);
 		}

--- a/tables/generate.c
+++ b/tables/generate.c
@@ -8,117 +8,117 @@
 // a/b/sej
 
 bool make_containing_folder(const char *const path) {
-    int last_slash = strlen(path);
-    while (path[last_slash - 1] != '/') {
-        last_slash -= 1;
-        if (last_slash == 0) {
-            fprintf(stderr, "Path appears to be relative to current dir, not making any folder.\n");
-            return true;
-        }
-    }
-    char *buffer = malloc(last_slash + 1);
-    strncpy(buffer, path, last_slash);
-    const int result = mkdir(buffer, S_IRWXU | S_IRWXG | S_IROTH);
-    if (errno == 0) {
-        fprintf(stderr, "Created %s\n", buffer);
-    }
-    else if (errno != EEXIST) {
-        fprintf(stderr, "Failed to create %s\n", buffer);
-    }
-    free(buffer);
-    return result == 0 || errno == EEXIST;
+	int last_slash = strlen(path);
+	while (path[last_slash - 1] != '/') {
+		last_slash -= 1;
+		if (last_slash == 0) {
+			fprintf(stderr, "Path appears to be relative to current dir, not making any folder.\n");
+			return true;
+		}
+	}
+	char *buffer = malloc(last_slash + 1);
+	strncpy(buffer, path, last_slash);
+	const int result = mkdir(buffer, S_IRWXU | S_IRWXG | S_IROTH);
+	if (errno == 0) {
+		fprintf(stderr, "Created %s\n", buffer);
+	}
+	else if (errno != EEXIST) {
+		fprintf(stderr, "Failed to create %s\n", buffer);
+	}
+	free(buffer);
+	return result == 0 || errno == EEXIST;
 }
 
 int main(int argc, const char **argv) {
-    if (argc != 4) {
-        printf("Usage: %s SOURCE DESTINATION HEADER\n", argv[0]);
-        return 1;
-    }
-    FILE *source = fopen(argv[1], "rb");
-    if (!source) {
-        perror("Error opening source file");
-        return 1;
-    }
-    if (!make_containing_folder(argv[2])) {
-       fprintf(stderr, "Error creating output's containing folder!\n");
-       return 1;
-    }
-    FILE *destination = fopen(argv[2], "wb");
-    if (!destination) {
-        perror("Error opening destination file");
-        fclose(source);
-        return 1;
-    }
-    FILE *header = fopen(argv[3], "wb");
-    if (!header) {
-        perror("Error opening header file");
-        fclose(source);
-        fclose(destination);
-        return 1;
-    }
-    int return_code = 1;
+	if (argc != 4) {
+		printf("Usage: %s SOURCE DESTINATION HEADER\n", argv[0]);
+		return 1;
+	}
+	FILE *source = fopen(argv[1], "rb");
+	if (!source) {
+		perror("Error opening source file");
+		return 1;
+	}
+	if (!make_containing_folder(argv[2])) {
+	   fprintf(stderr, "Error creating output's containing folder!\n");
+	   return 1;
+	}
+	FILE *destination = fopen(argv[2], "wb");
+	if (!destination) {
+		perror("Error opening destination file");
+		fclose(source);
+		return 1;
+	}
+	FILE *header = fopen(argv[3], "wb");
+	if (!header) {
+		perror("Error opening header file");
+		fclose(source);
+		fclose(destination);
+		return 1;
+	}
+	int return_code = 1;
 
-    if (fseek(source, 0, SEEK_END) != 0) {
-        puts("Seek failed!");
-        goto cleanup;
-    }
-    long length = ftell(source);
-    if (length == -1) {
-        puts("Failed to determine source file size!");
-        goto cleanup;
-    }
-    rewind(source);
-    char *buf = malloc(length);
-    if (!buf) {
-        puts("out of memory!");
-        goto cleanup;
-    }
-    if (fread(buf, 1, length, source) != (size_t)length) {
-        puts("Failed to read source file into buffer!");
-        goto cleanup;
-    }
+	if (fseek(source, 0, SEEK_END) != 0) {
+		puts("Seek failed!");
+		goto cleanup;
+	}
+	long length = ftell(source);
+	if (length == -1) {
+		puts("Failed to determine source file size!");
+		goto cleanup;
+	}
+	rewind(source);
+	char *buf = malloc(length);
+	if (!buf) {
+		puts("out of memory!");
+		goto cleanup;
+	}
+	if (fread(buf, 1, length, source) != (size_t)length) {
+		puts("Failed to read source file into buffer!");
+		goto cleanup;
+	}
 
-    if (fprintf(destination, "const char z80_tab[%lu] = {", length + 1) < 0) {
-        puts("Failed to print to file!");
-        goto cleanup;
-    }
-    if (fprintf(header, "#ifndef Z80_TABLE\n#define Z80_TABLE\n\nextern const char z80_tab[%lu];\n\n#endif\n", length + 1) < 0) {
-        puts("Failed to write header!");
-        goto cleanup;
-    }
-    for (long i = 0; i < length; i++) {
-        if (fprintf(destination, "%s0x%02x,", i % 8 == 0 ? "\n\t" : " ", buf[i]) < 0) {
-            puts("Failed to print to file!");
-            goto cleanup;
-        }
-    }
+	if (fprintf(destination, "const char z80_tab[%lu] = {", length + 1) < 0) {
+		puts("Failed to print to file!");
+		goto cleanup;
+	}
+	if (fprintf(header, "#ifndef Z80_TABLE\n#define Z80_TABLE\n\nextern const char z80_tab[%lu];\n\n#endif\n", length + 1) < 0) {
+		puts("Failed to write header!");
+		goto cleanup;
+	}
+	for (long i = 0; i < length; i++) {
+		if (fprintf(destination, "%s0x%02x,", i % 8 == 0 ? "\n\t" : " ", buf[i]) < 0) {
+			puts("Failed to print to file!");
+			goto cleanup;
+		}
+	}
 
-    if (fwrite("\n\t0,\n};\n", 1, 8, destination) != 8) {
-        puts("Failed to write to file!");
-        goto cleanup;
-    }
-    return_code = 0;
+	if (fwrite("\n\t0,\n};\n", 1, 8, destination) != 8) {
+		puts("Failed to write to file!");
+		goto cleanup;
+	}
+	return_code = 0;
 cleanup:
-    if (fflush(destination) != 0) {
-        puts("Failed to flush file!");
-        return_code = 1;
-    }
-    if (fflush(header) != 0) {
-        puts("Failed to flush header file!");
-        return_code = 1;
-    }
-    if (fclose(destination) != 0) {
-        puts("Failed to close output file!");
-        return_code = 1;
-    }
-    if (fclose(header) != 0) {
-        puts("Failed to close header file!");
-        return_code = 1;
-    }
-    if (fclose(source) != 0) {
-        puts("Failed to close input file!");
-        return_code = 1;
-    }
+	if (fflush(destination) != 0) {
+		puts("Failed to flush file!");
+		return_code = 1;
+	}
+	if (fflush(header) != 0) {
+		puts("Failed to flush header file!");
+		return_code = 1;
+	}
+	if (fclose(destination) != 0) {
+		puts("Failed to close output file!");
+		return_code = 1;
+	}
+	if (fclose(header) != 0) {
+		puts("Failed to close header file!");
+		return_code = 1;
+	}
+	if (fclose(source) != 0) {
+		puts("Failed to close input file!");
+		return_code = 1;
+	}
 
-    return return_code;
+	return return_code;
 }


### PR DESCRIPTION
This brings the total leaked memory when building a hello world from C down from 964251 bytes to 1418 bytes
```
Before:

==30861==    definitely lost: 11,283 bytes in 723 blocks
==30861==    indirectly lost: 73,558 bytes in 1,333 blocks

==31235==    definitely lost: 21,591 bytes in 1,491 blocks
==31235==    indirectly lost: 216,110 bytes in 4,973 blocks

==31493==    definitely lost: 39,782 bytes in 1,570 blocks
==31493==    indirectly lost: 601,927 bytes in 11,856 blocks

After:

==27438==    definitely lost: 755 bytes in 16 blocks
==27438==    indirectly lost: 382 bytes in 16 blocks

==27819==    definitely lost: 221 bytes in 34 blocks
==27819==    indirectly lost: 60 bytes in 4 blocks

==28127==    definitely lost: 0 bytes in 0 blocks
==28127==    indirectly lost: 0 bytes in 0 blocks
```

In order, those are main.asm -> main.o assembly (precompiled from main.c), crt0.asm -> crt0.o assembly, and linking into bin/root/bin/hello.

This also fixes every single compiler warning :)